### PR TITLE
support inline values in parameters

### DIFF
--- a/graphql_client/core.py
+++ b/graphql_client/core.py
@@ -4,6 +4,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class Operation:
 
     def __init__(
@@ -161,16 +162,23 @@ class Parameter:
     def __init__(
         self,
         parameter_name,
-        variable_name
+        variable_name=None,
+        value=None,
+        quote_value=False,
     ):
         self.parameter_name = parameter_name
-        self.variable_name= variable_name
+        self.variable_name = variable_name
+        self.value = value
+        self.quote_value = quote_value
 
     def request_body_string(self):
-        request_string = '{}: {}'.format(
-            self.parameter_name,
-            f'${self.variable_name}'
-        )
+        if self.variable_name is not None:
+            request_string = '{}: {}'.format(
+                self.parameter_name,
+                f'${self.variable_name}'
+                )
+        else:
+            request_string = f'{self.parameter_name}: {graphql_client.utils.json2gql(self.value)}'
         return request_string
 
 def indent(

--- a/graphql_client/utils.py
+++ b/graphql_client/utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -18,3 +19,8 @@ def graphql_json_dumps(object, indent='  '):
         cls=GraphQLJsonEncoder,
         indent=indent
     )
+
+
+def json2gql(data):
+    json_data = json.dumps(data)
+    return re.sub(r'"(.*?)"(?=:)', r'\1', json_data)

--- a/graphql_client/utils.py
+++ b/graphql_client/utils.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import json
 import logging
 import re
@@ -7,6 +8,8 @@ logger = logging.getLogger(__name__)
 class GraphQLJsonEncoder(json.JSONEncoder):
 
     def default(self, obj):
+        if isinstance(obj, Enum):
+            return f"||{obj.name}||"
         if hasattr(obj, "graphql_json"):
             graphql_json = getattr(obj, "graphql_json")
             if callable(graphql_json):
@@ -22,5 +25,5 @@ def graphql_json_dumps(object, indent='  '):
 
 
 def json2gql(data):
-    json_data = json.dumps(data)
-    return re.sub(r'"(.*?)"(?=:)', r'\1', json_data)
+    json_data = graphql_json_dumps(data)
+    return re.sub(r'"(.*?)"(?=:)', r'\1', re.sub(r'"\|\|(.*?)\|\|"', r'\1', json_data))


### PR DESCRIPTION
here is one idea to support inline parameters.

if it is a variable ref then use it the existing way by specifying the  `variable_name` otherwise use `value` and that value will be encoded to a modified JSON encoding, where keys are not quoted.